### PR TITLE
fix - delete Alert::

### DIFF
--- a/views/frontend/form.view.php
+++ b/views/frontend/form.view.php
@@ -1,5 +1,5 @@
-<?php if (Notification::get('success')) Alert::success(Notification::get('success')); ?>
-<?php if (Notification::get('error')) Alert::error(Notification::get('error')); ?>
+<?php if (Notification::get('success')) echo Notification::get('success'); ?>
+<?php if (Notification::get('error'))  echo Notification::get('error'); ?>
 <br />
 <form method="post">
     <?php echo (Form::hidden('csrf', Security::token())); ?>


### PR DESCRIPTION
Алерт не работает в монстре3 на фронэнде.  А для плагин контакта он тем более не нужен, т.к кому надо, сами сделают нужные стили на основе текущего и выведут сообщение как надо.